### PR TITLE
add yarn build step to standalone guide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -60,6 +60,7 @@ git clone https://github.com/nhost/hasura-backend-plus.git
 cd hasura-backend-plus
 yarn
 cp .env.example .env
+yarn build
 yarn start
 ```
 


### PR DESCRIPTION
The `yarn build` command is required to build the /dist before `yarn start` can be called.